### PR TITLE
Updated Stripe API Version

### DIFF
--- a/package.js
+++ b/package.js
@@ -5,7 +5,7 @@ Package.describe({
 	git: "https://github.com/grovelabs/meteor-stripe-npm.git"
 });
 
-Npm.depends({ "stripe": "2.8.0" });
+Npm.depends({ "stripe": "3.3.4" });
 
 Package.onUse(function (api) {
   api.addFiles('npm.stripe.js', 'server');


### PR DESCRIPTION
The newer version of stripe has new functionality for Stripe Connect.
In order for us to take advantage of this the dependency needs to be
updated to 3.3.4
